### PR TITLE
Upgrade http and vcr dependencies

### DIFF
--- a/contentful_lite.gemspec
+++ b/contentful_lite.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", '~> 3.9'
   spec.add_development_dependency "webmock", '~> 3.18'
   spec.add_development_dependency "simplecov", '~> 0.17'
-  spec.add_development_dependency "vcr", '~> 5.0'
+  spec.add_development_dependency "vcr", '~> 6.0'
   spec.add_development_dependency "rubocop", '~> 0.79'
 end

--- a/contentful_lite.gemspec
+++ b/contentful_lite.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["spec/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "http", '~> 4'
+  spec.add_dependency "http", '~> 5.0'
   spec.add_dependency "activemodel", '>= 6.0'
 
   spec.add_development_dependency "rspec", '~> 3.9'

--- a/lib/contentful_lite/version.rb
+++ b/lib/contentful_lite/version.rb
@@ -1,3 +1,3 @@
 module ContentfulLite
-  VERSION = "2.0.1".freeze
+  VERSION = "2.1.0".freeze
 end


### PR DESCRIPTION
In order to upgrade cognito-client to http v5, we need to upgrade
contentful_lite as well.

The desire to move to http v5 is due to replace the no longer maintained
http-parser library with llhttp-ffi.

Also upgrades VCR to fix warning:
Fixes:
/Users/jeff.dutil/.gem/ruby/3.2.2/bin/bundle: warning: Exception in finalizer #<Proc:0x0000000110e58970 /Users/jeff.dutil/.gem/ruby/3.2.2/gems/vcr-5.1.0/lib/vcr/library_hooks/webmock.rb:36 (lambda)>
/Users/jeff.dutil/.gem/ruby/3.2.2/gems/vcr-5.1.0/lib/vcr/library_hooks/webmock.rb:36:in `block in global_hook_disabled_requests': wrong number of arguments (given 1, expected 0) (ArgumentError)
