### PR TITLE
Rescue invalid JSON parsing

### DIFF
--- a/lib/contentful_lite/client.rb
+++ b/lib/contentful_lite/client.rb
@@ -94,6 +94,8 @@ module ContentfulLite
       JSON.parse(body).tap do |parsed|
         raise error_class(response.status).new(response, parsed) if response.status != 200
       end
+    rescue JSON::ParserError
+      raise error_class(response.status).new(response, body)
     end
 
     def request_headers

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe ContentfulLite::Client do
       it { is_expected.to be_a(ContentfulLite::EntriesArray) }
       it { expect(subject.size).to eq 2 }
     end
+
+    context 'response JSON is invalid' do
+      before do
+        stub_request(:get, %r{contentful.com/spaces/.*/entries}).
+          to_return(body: "connection failure")
+      end
+
+      it do
+        expect { subject }.to raise_error(
+          ContentfulLite::Client::RequestError,
+          "Invalid Contentful Response: connection failure"
+        )
+      end
+    end
   end
 
   describe '#entry' do


### PR DESCRIPTION
Sometimes the response on some failures is not a valid JSON and must be handled.